### PR TITLE
Rearange Emulator and Simulator types

### DIFF
--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1,11 +1,16 @@
 //! Implementation of an emulator of RISC-U (RV64I subset)
 
-use crate::Cpu;
+use crate::Registers;
 
-pub type Emulator = Cpu<u64>;
+#[derive(Default)]
+pub struct Emulator<T> {
+    pub(crate) pc: T,
+    pub(crate) regs: Registers<T>,
+    pub(crate) mem: Vec<u8>,
+}
 
 // Emulated instructions
-impl Cpu<u64> {
+impl Emulator<u64> {
     // #### Initialization
 
     // `lui rd,imm`: `rd = imm * 2^12; pc = pc + 4` with `-2^19 <= imm < 2^19`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,9 +30,3 @@ impl<T> IndexMut<usize> for Registers<T> {
         }
     }
 }
-
-#[derive(Default)]
-pub struct Cpu<T> {
-    pc: T,
-    regs: Registers<T>,
-}

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -2,7 +2,7 @@
 //! implementing the verification of each instruction via Lasso decomposable tables with some small
 //! arithmetic constraints.
 
-use crate::Cpu;
+use crate::Registers;
 
 use ark_bn254::fr::Fr as F;
 use ark_ff::{biginteger::BigInteger, Field, PrimeField};
@@ -144,14 +144,21 @@ impl LookupTables {
     }
 }
 
-pub type Simulator = Cpu<F>;
+#[derive(Default)]
+pub struct Simulator {
+    pub(crate) pc: F,
+    pub(crate) regs: Registers<F>,
+    // TODO: Memory simulation
+    // TODO: W
+    // TODO: C
+}
 
 // TODO, move these two constants to parameters of the object.
 const W: usize = 64;
 const C: usize = 4;
 
 // Simulated zk circuit instructions with Lasso lookups
-impl Cpu<F> {
+impl Simulator {
     // #### Initialization
 
     // `lui rd,imm`: `rd = imm * 2^12; pc = pc + 4` with `-2^19 <= imm < 2^19`

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,9 @@
-use crate::emulator::Emulator;
+use crate::emulator::Emulator as GenericEmulator;
 use crate::simulator::Simulator;
 
 use ark_bn254::fr::Fr as F;
+
+type Emulator = GenericEmulator<u64>;
 
 fn extend_cases_commutative(cases: &mut Vec<(u64, u64, u64)>) {
     let commuted: Vec<(u64, u64, u64)> = cases


### PR DESCRIPTION
Use different types for Emulator and Simulator (instead of sharing a generic
type), so that we can can introduce specific fields for each one.

~~Depends on https://github.com/ed255/riscu-jolt/pull/9 (only consider the last commit of this branch for this PR.  Once #9 is merged I will rebase this branch)~~