### PR TITLE
Add control transfer instructions in emulator

### DIFF
--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -81,8 +81,9 @@ impl Cpu<u64> {
     // `beq rs1,rs2,imm`: `if (rs1 == rs2) { pc = pc + imm } else { pc = pc + 4 }` with `-2^12 <= imm < 2^12` and `imm % 2 == 0`
     pub fn beq(&mut self, rs1: usize, rs2: usize, imm: i64) {
         if self.regs[rs1] == self.regs[rs2] {
-            // TODO: Raising instruction-address-misaligned exception
-            assert!(imm < 2 << 11 && imm >= -(2 << 11));
+            assert!(imm < 2 << 12 && imm >= -(2 << 12));
+            assert_eq!(imm % 2, 0);
+            assert_eq!(imm % 4, 0, "instruction-address-misaligned");
             let pc = self.pc as i128;
             self.pc = (pc + imm as i128) as u64;
         } else {
@@ -91,16 +92,17 @@ impl Cpu<u64> {
     }
     // `jal rd,imm`: `rd = pc + 4; pc = pc + imm` with `-2^20 <= imm < 2^20` and `imm % 2 == 0`
     pub fn jal(&mut self, rd: usize, imm: i64) {
-        // TODO: Raising instruction-address-misaligned exception
-        assert!(imm < 2 << 11 && imm >= -(2 << 11));
+        assert!(imm < 2 << 12 && imm >= -(2 << 12));
+        assert_eq!(imm % 2, 0);
+        assert_eq!(imm % 4, 0, "instruction-address-misaligned");
         let pc = self.pc as i128;
         self.pc = (pc + imm as i128) as u64;
         self.regs[rd] = self.pc;
     }
     // `jalr rd,imm(rs1)`: `tmp = ((rs1 + imm) / 2) * 2; rd = pc + 4; pc = tmp` with `-2^11 <= imm < 2^11`
     pub fn jalr(&mut self, rd: usize, rs1: usize, imm: i64) {
-        // TODO: Raising instruction-address-misaligned exception
-        assert!(imm < 2 << 11 && imm >= -(2 << 11));
+        assert!(imm < 2 << 12 && imm >= -(2 << 12));
+        assert_eq!(imm % 2, 0);
         let tmp = ((self.regs[rs1] as i128 + imm as i128) / 2) * 2;
         self.regs[rd] = self.pc + 4;
         self.pc = tmp as u64;

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -79,11 +79,33 @@ impl Cpu<u64> {
     // #### Control
 
     // `beq rs1,rs2,imm`: `if (rs1 == rs2) { pc = pc + imm } else { pc = pc + 4 }` with `-2^12 <= imm < 2^12` and `imm % 2 == 0`
-    // TODO
+    pub fn beq(&mut self, rs1: usize, rs2: usize, imm: i64) {
+        if self.regs[rs1] == self.regs[rs2] {
+            // TODO: Raising instruction-address-misaligned exception
+            assert!(imm < 2 << 11 && imm >= -(2 << 11));
+            let pc = self.pc as i128;
+            self.pc = (pc + imm as i128) as u64;
+        } else {
+            self.pc = self.pc + 4;
+        }
+    }
     // `jal rd,imm`: `rd = pc + 4; pc = pc + imm` with `-2^20 <= imm < 2^20` and `imm % 2 == 0`
-    // TODO
+    pub fn jal(&mut self, rd: usize, imm: i64) {
+        // TODO: Raising instruction-address-misaligned exception
+        assert!(imm < 2 << 11 && imm >= -(2 << 11));
+        let pc = self.pc as i128;
+        self.pc = (pc + imm as i128) as u64;
+        self.regs[rd] = self.pc;
+    }
     // `jalr rd,imm(rs1)`: `tmp = ((rs1 + imm) / 2) * 2; rd = pc + 4; pc = tmp` with `-2^11 <= imm < 2^11`
-    // TODO
+    pub fn jalr(&mut self, rd: usize, rs1: usize, imm: i64) {
+        // TODO: Raising instruction-address-misaligned exception
+        assert!(imm < 2 << 11 && imm >= -(2 << 11));
+        let tmp = ((self.regs[rs1] as i128 + imm as i128) / 2) * 2;
+        self.regs[rd] = self.pc + 4;
+        self.pc = tmp as u64;
+    }
+
     // #### System
 
     // `ecall`: system call number is in `a7`, actual parameters are in `a0-a3`, return value is in `a0`.

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -102,8 +102,8 @@ impl Cpu<u64> {
     // `jalr rd,imm(rs1)`: `tmp = ((rs1 + imm) / 2) * 2; rd = pc + 4; pc = tmp` with `-2^11 <= imm < 2^11`
     pub fn jalr(&mut self, rd: usize, rs1: usize, imm: i64) {
         assert!(imm < 2 << 12 && imm >= -(2 << 12));
-        assert_eq!(imm % 2, 0);
         let tmp = ((self.regs[rs1] as i128 + imm as i128) / 2) * 2;
+        assert_eq!(tmp % 4, 0, "instruction-address-misaligned");
         self.regs[rd] = self.pc + 4;
         self.pc = tmp as u64;
     }

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -84,15 +84,15 @@ impl Cpu<u64> {
             assert!(imm < 2 << 12 && imm >= -(2 << 12));
             assert_eq!(imm % 2, 0);
             assert_eq!(imm % 4, 0, "instruction-address-misaligned");
-            let pc = self.pc as i128;
-            self.pc = (pc + imm as i128) as u64;
+            let pc = self.pc as i64;
+            self.pc = (pc + imm as i64) as u64;
         } else {
             self.pc = self.pc + 4;
         }
     }
     // `jal rd,imm`: `rd = pc + 4; pc = pc + imm` with `-2^20 <= imm < 2^20` and `imm % 2 == 0`
     pub fn jal(&mut self, rd: usize, imm: i64) {
-        assert!(imm < 2 << 12 && imm >= -(2 << 12));
+        assert!(imm < 2 << 20 && imm >= -(2 << 20));
         assert_eq!(imm % 2, 0);
         assert_eq!(imm % 4, 0, "instruction-address-misaligned");
         let pc = self.pc as i128;


### PR DESCRIPTION
I implemented control transfer instructions (`beq`, `jal`, `jalr`) in emulator. (#2)