### PR TITLE
Soowon/Implement control transfer instructions in simulator

### DIFF
--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -328,18 +328,18 @@ impl<F: PrimeField> Simulator<F> {
     // `jal rd,imm`: `rd = pc + 4; pc = pc + imm` with `-2^20 <= imm < 2^20` and `imm % 2 == 0`
     pub fn t_jal(&mut self, rd: usize, imm: u32) {
         // Ref: Jolt 5.6
-        let z = self.pc + F::from(imm) + F::from(4u32);
+        let z = self.pc + F::from(imm);
         // MLE. z has W+1 bits.  Take lowest W bits via lookup table
         let result = LookupTables::wp1_to_w(W, z);
         self.regs[rd] = self.pc + F::from(4u32);
-        self.pc = result - F::from(4u32);
+        self.pc = result;
     }
     // `jalr rd,imm(rs1)`: `tmp = ((rs1 + imm) / 2) * 2;
     // rd = pc + 4; pc = tmp` with `-2^11 <= imm < 2^11`
     pub fn t_jalr(&mut self, rd: usize, rs1: usize, imm: u32) {
         // Ref: Jolt 5.6
         // In the paper, it checks z = pc + imm + 4, but it seems wrong
-        let z = self.regs[rs1] + F::from(imm) + F::from(4u32);
+        let z = self.regs[rs1] + F::from(imm);
         // MLE. z has W+1 bits.  Take lowest W bits via lookup table
         let result = LookupTables::wp1_to_w(W, z);
         let tmp = self.regs[rs1] + F::from(imm);


### PR DESCRIPTION
I implemented control transfer instructions (`beq`, `jal`, `jalr`) in simulator.