### PR TITLE
Edu/mem trace

### DIFF
--- a/src/bin/emulator.rs
+++ b/src/bin/emulator.rs
@@ -1,5 +1,9 @@
 use riscu::emulator::decoder::decode;
-use riscu::emulator::{Emulator, Memory};
+use riscu::emulator::{
+    memory::Memory,
+    memory::{MemoryTracer, RiscvPkMemoryMap},
+    Emulator,
+};
 
 use elf::endian::LittleEndian;
 use elf::ElfBytes;
@@ -42,7 +46,9 @@ fn main() -> Result<(), pico_args::Error> {
     let slice = file_data.as_slice();
     let file = ElfBytes::<LittleEndian>::minimal_parse(slice).expect("Open test1");
     // 1 MiB memory
-    let mut emu = Emulator::<u64, _>::new_pk_from_elf(1 * 1024 * 1024, &file);
+    let mem = RiscvPkMemoryMap::new_load_from_elf(1 * 1024 * 1024, &file);
+    let mem = MemoryTracer::new(mem);
+    let mut emu = Emulator::<u64, _>::new(mem);
     let mut t: u64 = 0;
     loop {
         if args.debug >= 2 {
@@ -60,6 +66,11 @@ fn main() -> Result<(), pico_args::Error> {
             // Decode
             let inst = decode(inst_u32);
             println!("t={:05} 0x{:06x} {:08x} {:?}", t, emu.pc, inst_u32, inst);
+        }
+        if t == 00238 {
+            for mem_op in &emu.mem.trace {
+                println!("{:?}", mem_op);
+            }
         }
         emu.step();
         t += 1;

--- a/src/bin/emulator.rs
+++ b/src/bin/emulator.rs
@@ -1,9 +1,5 @@
 use riscu::emulator::decoder::decode;
-use riscu::emulator::{
-    memory::Memory,
-    memory::{MemoryTracer, RiscvPkMemoryMap},
-    Emulator,
-};
+use riscu::emulator::{memory::Memory, memory::RiscvPkMemoryMap, Emulator};
 
 use elf::endian::LittleEndian;
 use elf::ElfBytes;
@@ -47,8 +43,7 @@ fn main() -> Result<(), pico_args::Error> {
     let file = ElfBytes::<LittleEndian>::minimal_parse(slice).expect("Open test1");
     // 1 MiB memory
     let mem = RiscvPkMemoryMap::new_load_from_elf(1 * 1024 * 1024, &file);
-    let mem = MemoryTracer::new(mem);
-    let mut emu = Emulator::<u64, _>::new(mem);
+    let mut emu = Emulator::<u64, _>::new_tracer(mem);
     let mut t: u64 = 0;
     loop {
         if args.debug >= 2 {
@@ -67,12 +62,13 @@ fn main() -> Result<(), pico_args::Error> {
             let inst = decode(inst_u32);
             println!("t={:05} 0x{:06x} {:08x} {:?}", t, emu.pc, inst_u32, inst);
         }
-        if t == 00238 {
-            for mem_op in &emu.mem.trace {
-                println!("{:?}", mem_op);
-            }
-        }
-        emu.step();
+        // if t == 00238 {
+        //     for mem_op in &emu.mem.trace {
+        //         println!("{:?}", mem_op);
+        //     }
+        // }
+        let step = emu.step_trace();
+        println!("{:?}", step);
         t += 1;
     }
 }

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -73,7 +73,6 @@ impl<M: Memory> Emulator<u64, M> {
     pub fn ld(&mut self, rd: usize, rs1: usize, imm: i64) {
         debug_assert!(-(1 << 11) <= imm && imm < 1 << 11);
         let (addr, _) = self.regs[rs1].overflowing_add(imm as u64);
-        assert!(addr % 8 == 0, "load-address-misaligned");
         self.regs[rd] = self.mem.read_u64(addr);
         self.pc = self.pc + 4;
     }
@@ -81,7 +80,6 @@ impl<M: Memory> Emulator<u64, M> {
     pub fn sd(&mut self, rs1: usize, rs2: usize, imm: i64) {
         debug_assert!(-(1 << 11) <= imm && imm < 1 << 11);
         let (addr, _) = self.regs[rs1].overflowing_add(imm as u64);
-        assert!(addr % 8 == 0, "store-address-misaligned");
         self.mem.write_u64(addr, self.regs[rs2]);
         self.pc = self.pc + 4;
     }

--- a/src/emulator/memory.rs
+++ b/src/emulator/memory.rs
@@ -200,3 +200,17 @@ impl<M: Memory> Memory for MemoryTracer<M> {
         self.mem.entry_point()
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_new_load_from_elf() {
+        let path = std::path::PathBuf::from("riscu_examples/c/fibo.bin");
+        let file_data = std::fs::read(path).expect("Could not read file.");
+        let slice = file_data.as_slice();
+        let file = ElfBytes::<LittleEndian>::minimal_parse(slice).expect("Open test1");
+        let mem = RiscvPkMemoryMap::new_load_from_elf(1024 * 1024, &file);
+    }
+}

--- a/src/emulator/memory.rs
+++ b/src/emulator/memory.rs
@@ -8,11 +8,13 @@ pub trait Memory {
     fn read_u8(&mut self, addr: u64) -> u8;
 
     fn read_u32(&mut self, addr: u64) -> u32 {
+        assert!(addr % 4 == 0, "read-address-misaligned");
         let data = [0, 1, 2, 3].map(|i| self.read_u8(addr + i));
         u32::from_le_bytes(data)
     }
 
     fn read_u64(&mut self, addr: u64) -> u64 {
+        assert!(addr % 8 == 0, "read-address-misaligned");
         let data = [0, 1, 2, 3, 4, 5, 6, 7].map(|i| self.read_u8(addr + i));
         u64::from_le_bytes(data)
     }
@@ -20,6 +22,7 @@ pub trait Memory {
     fn write_u8(&mut self, addr: u64, value: u8);
 
     fn write_u64(&mut self, addr: u64, value: u64) {
+        assert!(addr % 8 == 0, "write-address-misaligned");
         let data = value.to_le_bytes();
         data.iter()
             .enumerate()

--- a/src/emulator/memory.rs
+++ b/src/emulator/memory.rs
@@ -1,0 +1,202 @@
+use crate::{MemOp, RW};
+
+use elf::abi::PF_X;
+use elf::endian::LittleEndian;
+use elf::ElfBytes;
+
+pub trait Memory {
+    fn read_u8(&mut self, addr: u64) -> u8;
+
+    fn read_u32(&mut self, addr: u64) -> u32 {
+        let data = [0, 1, 2, 3].map(|i| self.read_u8(addr + i));
+        u32::from_le_bytes(data)
+    }
+
+    fn read_u64(&mut self, addr: u64) -> u64 {
+        let data = [0, 1, 2, 3, 4, 5, 6, 7].map(|i| self.read_u8(addr + i));
+        u64::from_le_bytes(data)
+    }
+
+    fn write_u8(&mut self, addr: u64, value: u8);
+
+    fn write_u64(&mut self, addr: u64, value: u64) {
+        let data = value.to_le_bytes();
+        data.iter()
+            .enumerate()
+            .for_each(|(i, b)| self.write_u8(addr + i as u64, *b));
+    }
+
+    // Return inital stack pointer
+    fn sp(&self) -> u64;
+
+    fn entry_point(&self) -> u64;
+}
+
+#[derive(Default)]
+pub struct NoMem;
+
+impl Memory for NoMem {
+    fn read_u8(&mut self, addr: u64) -> u8 {
+        panic!("No memory")
+    }
+
+    fn write_u8(&mut self, addr: u64, value: u8) {
+        panic!("No memory")
+    }
+
+    fn sp(&self) -> u64 {
+        0
+    }
+
+    fn entry_point(&self) -> u64 {
+        0
+    }
+}
+
+// https://github.com/riscv-software-src/riscv-pk
+pub struct RiscvPkMemoryMap(Vec<u8>);
+
+pub const RISCV_PK_VMEM: u64 = 0x10000;
+pub const RISCV_PK_ENTRY_POINT: u64 = RISCV_PK_VMEM;
+
+impl RiscvPkMemoryMap {
+    pub fn new(mem_size: usize) -> Self {
+        Self(vec![0; mem_size])
+    }
+
+    pub fn new_load(mem_size: usize, text: &[u8], data_addr: usize, data: &[u8]) -> Self {
+        let mut mem = RiscvPkMemoryMap::new(mem_size);
+        mem.load(text, data_addr, data);
+        mem
+    }
+
+    pub fn new_load_from_elf(mem_size: usize, file: &ElfBytes<LittleEndian>) -> Self {
+        let entry_point = file.ehdr.e_entry;
+        assert_eq!(file.ehdr.e_entry, RISCV_PK_ENTRY_POINT);
+        let mut text_segment = None;
+        let mut data_segment = None;
+        let segments = file.segments().expect("Get segments");
+        for segment in segments.iter() {
+            if segment.p_flags & PF_X != 0 {
+                if text_segment.is_some() {
+                    panic!("Found 2 executable segments");
+                }
+                text_segment = Some(segment);
+            } else {
+                if data_segment.is_some() {
+                    panic!("Found 2 data segments");
+                }
+                data_segment = Some(segment);
+            }
+        }
+        match (text_segment, data_segment) {
+            (Some(text_segment), Some(data_segment)) => {
+                let text = file.segment_data(&text_segment).expect("Get text bytes");
+                let data = file.segment_data(&data_segment).expect("Get data bytes");
+                let data_addr = data_segment.p_vaddr;
+                Self::new_load(mem_size, text, data_addr as usize, data)
+            }
+            (None, Some(_)) => panic!("Missing text segment"),
+            (Some(_), None) => panic!("Missing data segment"),
+            (None, None) => panic!("Missing text & data segment"),
+        }
+    }
+
+    pub fn load(&mut self, text: &[u8], data_addr: usize, data: &[u8]) {
+        assert!(text.len() < self.0.len());
+        assert!((data_addr - RISCV_PK_ENTRY_POINT as usize) + data.len() < self.0.len());
+        // Load text section
+        for (i, b) in text.iter().enumerate() {
+            self.write_u8(RISCV_PK_ENTRY_POINT + i as u64, text[i]);
+        }
+        // Load data section
+        for (i, b) in data.iter().enumerate() {
+            self.write_u8((data_addr + i) as u64, data[i]);
+        }
+    }
+
+    // Map address to RAM index
+    fn map(&self, addr: u64) -> u64 {
+        if addr < RISCV_PK_VMEM {
+            panic!("Invalid low address 0x{:x} < 0x{:x}", addr, RISCV_PK_VMEM);
+        } else if RISCV_PK_VMEM <= addr && addr < RISCV_PK_VMEM + self.0.len() as u64 {
+            addr - RISCV_PK_VMEM
+        } else {
+            panic!(
+                "Invalid high address 0x{:x} > 0x{:x}",
+                addr,
+                RISCV_PK_VMEM + self.0.len() as u64
+            );
+        }
+    }
+}
+
+impl Memory for RiscvPkMemoryMap {
+    fn read_u8(&mut self, addr: u64) -> u8 {
+        let index = self.map(addr) as usize;
+        self.0[index]
+    }
+
+    fn write_u8(&mut self, addr: u64, value: u8) {
+        let index = self.map(addr) as usize;
+        self.0[index] = value;
+    }
+
+    fn sp(&self) -> u64 {
+        RISCV_PK_ENTRY_POINT + self.0.len() as u64 - std::mem::size_of::<u64>() as u64
+    }
+
+    fn entry_point(&self) -> u64 {
+        RISCV_PK_ENTRY_POINT
+    }
+}
+
+#[derive(Debug)]
+pub struct MemoryTracer<M: Memory> {
+    mem: M,                // Memory state
+    pub trace: Vec<MemOp>, // Chronological trace of memory operations
+    t: u64,                // Timestamp counter
+}
+
+impl<M: Memory> MemoryTracer<M> {
+    pub fn new(mem: M) -> Self {
+        Self {
+            mem,
+            trace: Vec::new(),
+            t: 0,
+        }
+    }
+}
+
+impl<M: Memory> Memory for MemoryTracer<M> {
+    fn read_u8(&mut self, addr: u64) -> u8 {
+        let value = self.mem.read_u8(addr);
+        self.trace.push(MemOp {
+            addr,
+            t: self.t,
+            rw: RW::Read,
+            value,
+        });
+        self.t += 1;
+        value
+    }
+
+    fn write_u8(&mut self, addr: u64, value: u8) {
+        self.trace.push(MemOp {
+            addr,
+            t: self.t,
+            rw: RW::Write,
+            value,
+        });
+        self.t += 1;
+        self.mem.write_u8(addr, value)
+    }
+
+    fn sp(&self) -> u64 {
+        self.mem.sp()
+    }
+
+    fn entry_point(&self) -> u64 {
+        self.mem.entry_point()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,16 +114,3 @@ pub struct Step<T, I> {
     pub regs: Registers<T>,
     pub mem_ops: Vec<MemOp>,
 }
-
-/*
-impl<T, I> Step<T, I> {
-    fn into<I2: From<I>>(self) -> Step<T, I2> {
-        Step {
-            pc: self.pc,
-            inst: self.inst.into(),
-            regs: self.regs,
-            mem_ops: self.mem_ops,
-        }
-    }
-}
-*/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod simulator;
 mod tests;
 mod utils;
 
+use std::fmt::{self, Display};
 use std::ops::{Index, IndexMut};
 
 const REG_SP: usize = 2;
@@ -15,6 +16,15 @@ const REG_SP: usize = 2;
 pub struct Registers<T> {
     r: [T; 32],
     zero: T,
+}
+
+impl Registers<u64> {
+    pub fn into_f<F: From<u64>>(self) -> Registers<F> {
+        Registers {
+            r: self.r.map(|v| F::from(v)),
+            zero: F::from(self.zero),
+        }
+    }
 }
 
 impl<T> Index<usize> for Registers<T> {
@@ -49,3 +59,71 @@ pub struct MemOp {
     rw: RW,
     value: u8,
 }
+
+#[derive(Default, Debug, Clone, Copy)]
+pub enum Opcode {
+    // RISC-U supported opcodes
+    Lui,
+    Addi,
+    Ld,
+    Sd,
+    #[default]
+    Add,
+    Sub,
+    Mul,
+    Divu,
+    Remu,
+    Sltu,
+    Beq,
+    Jal,
+    Jalr,
+    Ecall,
+}
+
+impl Display for Opcode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct Instruction {
+    pub op: Opcode,
+    rd: usize,
+    rs1: usize,
+    rs2: usize,
+    imm: i64,
+}
+
+impl Instruction {
+    fn new(op: Opcode, rd: usize, rs1: usize, rs2: usize, imm: i64) -> Self {
+        Instruction {
+            op,
+            rd,
+            rs1,
+            rs2,
+            imm,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Step<T, I> {
+    pub pc: T,
+    pub inst: I,
+    pub regs: Registers<T>,
+    pub mem_ops: Vec<MemOp>,
+}
+
+/*
+impl<T, I> Step<T, I> {
+    fn into<I2: From<I>>(self) -> Step<T, I2> {
+        Step {
+            pc: self.pc,
+            inst: self.inst.into(),
+            regs: self.regs,
+            mem_ops: self.mem_ops,
+        }
+    }
+}
+*/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use std::ops::{Index, IndexMut};
 
 const REG_SP: usize = 2;
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone)]
 pub struct Registers<T> {
     r: [T; 32],
     zero: T,
@@ -35,14 +35,14 @@ impl<T> IndexMut<usize> for Registers<T> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum RW {
     Read = 0,
     Write = 1,
 }
 
 // Memory operation (read or write)
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MemOp {
     addr: u64,
     t: u64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,3 +34,18 @@ impl<T> IndexMut<usize> for Registers<T> {
         }
     }
 }
+
+#[derive(Debug)]
+pub enum RW {
+    Read = 0,
+    Write = 1,
+}
+
+// Memory operation (read or write)
+#[derive(Debug)]
+pub struct MemOp {
+    addr: u64,
+    t: u64,
+    rw: RW,
+    value: u8,
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::emulator::{Emulator as GenericEmulator, NoMem};
+use crate::emulator::{memory::NoMem, Emulator as GenericEmulator};
 use crate::simulator::Simulator;
 
 use ark_bn254::fr::Fr;


### PR DESCRIPTION
- bin/Emulator
  - Enable flag to simulate verifier for every step run in the emulator
- Memory (new module)
  - Implement a wrapper over a Memory that traces every access with the MemOp type
  - Check memory alignment in reads/writes
- Emulator
  - Move memory implementation to its own module
  - Implement a tracer that returns the state before executing an instruction with the instruction details and memory operations that happen in that step
  - Implement `exec` which gets an already decoded instruction (useful for testing)
- Simulator
  - Refactor the instructions to verify the correct transition between a step and the next step.  The step is an extension of the Emulator Step (Resolve https://github.com/ed255/riscu-jolt/issues/20)
- Tests
  - Update instruction tests to use the new refactored simulation: Run a transition in the emulator, and verify it with the simulator.