### PR TITLE
Simulate LD and SD

### DIFF
--- a/src/bin/emulator.rs
+++ b/src/bin/emulator.rs
@@ -71,6 +71,7 @@ fn main() -> Result<(), pico_args::Error> {
                 inst: Instruction::default(),
                 regs: emu.regs.clone(),
                 mem_ops: Vec::new(),
+                mem_t: emu.mem.t,
             };
             let step: JoltStep<Fr> = step.into();
             let step_next: JoltStep<Fr> = step_next.into();

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -224,7 +224,7 @@ impl<M: Memory> Emulator<u64, M> {
     }
     pub fn step(&mut self) -> Instruction {
         // Fetch
-        let inst_u32 = self.mem.read_u32(self.pc);
+        let inst_u32 = self.mem.fetch_u32(self.pc);
         // Decode
         let inst = decode(inst_u32).expect("Valid instruction");
         self.exec(inst.clone());
@@ -236,6 +236,7 @@ impl<M: Memory> Emulator<u64, MemoryTracer<M>> {
     pub fn exec_trace(&mut self, inst: Instruction) -> Step<u64> {
         let pc = self.pc;
         let regs = self.regs.clone();
+        let mem_t = self.mem.t;
         self.exec(inst.clone());
         // For this method we skipped the instruction fetch, so all the memory ops come from
         // instruction execution.
@@ -245,12 +246,14 @@ impl<M: Memory> Emulator<u64, MemoryTracer<M>> {
             inst,
             pc,
             regs,
+            mem_t,
             mem_ops,
         }
     }
     pub fn step_trace(&mut self) -> Step<u64> {
         let pc = self.pc;
         let regs = self.regs.clone();
+        let mem_t = self.mem.t;
         let inst = self.step();
         // The memory trace contains 4 entries for fetching the instruction (32 bits) and optionally more entries
         // from load / store instruction
@@ -260,6 +263,7 @@ impl<M: Memory> Emulator<u64, MemoryTracer<M>> {
             inst,
             pc,
             regs,
+            mem_t,
             mem_ops,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ impl<T> IndexMut<usize> for Registers<T> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RW {
     Read = 0,
     Write = 1,
@@ -112,5 +112,6 @@ pub struct Step<T, I> {
     pub pc: T,
     pub inst: I,
     pub regs: Registers<T>,
+    pub mem_t: u64,
     pub mem_ops: Vec<MemOp>,
 }


### PR DESCRIPTION
Simulate LD and SD by the read/write operations that these instructions perform.  Each memory operation is for 1 byte, so LD and SD do 8 each to read/write 64 bits.
Since in Jolt the instruction fetching is not done through memory access, I added a new method called `fetch_u32` used for instruction fetching which is not traced.