### PR TITLE
Implement virtual extension in the emulator

### DIFF
--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -4,28 +4,146 @@ pub mod decoder;
 pub mod memory;
 
 use crate::Registers;
-use crate::REG_SP;
-use crate::{Instruction, Opcode, Step as GenericStep};
+use crate::{Instruction, Opcode, Step as GenericStep, VirtualOpcode};
+use crate::{REG_SP, REG_V0};
 use decoder::decode;
 use memory::{Memory, MemoryTracer};
 
+use std::collections::HashSet;
+
 type Step<T> = GenericStep<T, Instruction>;
+
+pub struct VirtPcMap {
+    base: u64,
+    map: Vec<u64>,
+}
+
+impl VirtPcMap {
+    fn new(base: u64, len: u64) -> Self {
+        Self {
+            base,
+            map: vec![0; len as usize],
+        }
+    }
+    // return the vpc corresponding to pc
+    fn get(&self, pc: u64) -> u64 {
+        self.map[((pc - self.base) / 4) as usize]
+    }
+    // Set the mapping between pc and vpc
+    fn set(&mut self, pc: u64, vpc: u64) {
+        self.map[((pc - self.base) / 4) as usize] = vpc;
+    }
+}
+
+pub struct Virt<T> {
+    // Virtual PC.  This program counter points to instruction position in rom.
+    pub pc: T,
+    // Map from PC to Virtual PC
+    pub vpc_map: VirtPcMap,
+    // The rom has all the decoded instructions of the program, where some instructions have been
+    // expanded using virtual instructions.
+    pub rom: Vec<Instruction>,
+    // Wether an instruction in the rom is the beginning of multi-step instruction (which
+    // means this is the first virtual instruction of a multi-step instruction)
+    pub begin_multi_step: HashSet<u64>,
+    // Advice buffer used in virtual instructions.  This vector is filled when a multi-step
+    // instruction is found with the advice values that subsequent ADVICE instructions will need.
+    pub advices: Vec<T>,
+    // Last advice used.  Instructions that consume an advice will store a copy here so that we
+    // can later get it for the trace.
+    pub last_advice: Option<T>,
+}
+
+impl<T: Default> Virt<T> {
+    fn new<M: Memory>(mem: &mut M) -> Self {
+        use Opcode::Virtual;
+        use VirtualOpcode::*;
+        let (text_addr, text_len) = mem.text();
+        let mut rom = Vec::with_capacity((text_len / 4) as usize);
+        let mut begin_multi_step = HashSet::new();
+        let mut vpc = 0;
+        let mut vpc_map = VirtPcMap::new(text_addr, text_len);
+        for addr in (text_addr..(text_addr + text_len)).step_by(4) {
+            vpc_map.set(addr, vpc);
+            let inst_u32 = mem.fetch_u32(addr);
+            let inst = decode(inst_u32).expect("Valid instruction");
+            // NOTE: We replace the virtual `MOVE` instruction defined in Jolt by an Add with the
+            // zero register, which is the canonical way to implement the `mv` pseudoinstruction in
+            // RISC-V.  See Table 25.2 in The RISC-V Instruction Set Manual, Volume I: Unprivileged
+            // ISA, Document Version 20191213
+            let virt_insts = match inst.op {
+                Opcode::Divu => {
+                    let [v0, vq, vr, vqy] = [0, 1, 2, 3].map(|i| REG_V0 + i);
+                    vec![
+                        Instruction::new(Virtual(Advice), vq, 0, 0, 0),
+                        Instruction::new(Virtual(Advice), vr, 0, 0, 0),
+                        Instruction::new(Virtual(Mul), vqy, vq, inst.rs2, 0),
+                        Instruction::new(Virtual(AssertLtu), 0, vr, inst.rs2, 0),
+                        Instruction::new(Virtual(AssertLte), 0, vqy, inst.rs1, 0),
+                        Instruction::new(Virtual(Add), v0, vqy, vr, 0),
+                        Instruction::new(Virtual(AssertEq), 0, v0, inst.rs1, 0),
+                        Instruction::new(Virtual(Add), inst.rd, vq, 0, 0),
+                    ]
+                }
+                Opcode::Remu => {
+                    let [v0, vq, vr, vqy] = [0, 1, 2, 3].map(|i| REG_V0 + i);
+                    vec![
+                        Instruction::new(Virtual(Advice), vq, 0, 0, 0),
+                        Instruction::new(Virtual(Advice), vr, 0, 0, 0),
+                        Instruction::new(Virtual(Mul), vqy, vq, inst.rs2, 0),
+                        Instruction::new(Virtual(AssertLtu), 0, vr, inst.rs2, 0),
+                        Instruction::new(Virtual(AssertLte), 0, vqy, inst.rs1, 0),
+                        Instruction::new(Virtual(Add), v0, vqy, vr, 0),
+                        Instruction::new(Virtual(AssertEq), 0, v0, inst.rs1, 0),
+                        Instruction::new(Virtual(Add), inst.rd, vr, 0, 0),
+                    ]
+                }
+                _ => {
+                    rom.push(inst);
+                    vpc += 1;
+                    continue;
+                }
+            };
+            begin_multi_step.insert(vpc);
+            for inst in virt_insts {
+                rom.push(inst);
+                vpc += 1;
+            }
+        }
+        Virt {
+            pc: T::default(),
+            vpc_map,
+            rom,
+            begin_multi_step,
+            advices: Vec::new(),
+            last_advice: None,
+        }
+    }
+}
 
 #[derive(Default)]
 pub struct Emulator<T, M: Memory> {
     pub pc: T,
     pub regs: Registers<T>,
     pub mem: M,
+    // Enable Jolt virtual behaviour
+    pub virt: Option<Virt<T>>,
 }
 
 impl<T: Default + From<u64>, M: Memory> Emulator<T, M> {
-    pub fn new(mem: M) -> Self {
+    pub fn new(mut mem: M, virt: bool) -> Self {
         let sp = mem.sp();
         let entry_point = mem.entry_point();
+        let virt = if virt {
+            Some(Virt::new(&mut mem))
+        } else {
+            None
+        };
         let mut emu = Emulator {
             pc: T::default(),
             regs: Registers::default(),
             mem,
+            virt,
         };
         emu.pc = entry_point.into();
         emu.regs[REG_SP] = sp.into();
@@ -34,9 +152,9 @@ impl<T: Default + From<u64>, M: Memory> Emulator<T, M> {
 }
 
 impl<T: Default + From<u64>, M: Memory> Emulator<T, MemoryTracer<M>> {
-    pub fn new_tracer(mem: M) -> Self {
+    pub fn new_tracer(mem: M, virt: bool) -> Self {
         let mem = MemoryTracer::new(mem);
-        Self::new(mem)
+        Self::new(mem, virt)
     }
 }
 
@@ -50,6 +168,7 @@ const SYSCALL_BRK: u64 = 214;
 impl<M: Memory> Emulator<u64, M> {
     pub fn nop(&mut self) {
         self.pc = self.pc + 4;
+        self.virt.as_mut().map(|v| v.pc += 1);
     }
     // #### Initialization
 
@@ -58,6 +177,7 @@ impl<M: Memory> Emulator<u64, M> {
         debug_assert_eq!(imm & ((1 << 12) - 1), 0);
         self.regs[rd] = imm as u64;
         self.pc = self.pc + 4;
+        self.virt.as_mut().map(|v| v.pc += 1);
     }
     // `addi rd,rs1,imm`: `rd = rs1 + imm; pc = pc + 4` with `-2^11 <= imm < 2^11`
     pub fn addi(&mut self, rd: usize, rs1: usize, imm: i64) {
@@ -65,6 +185,7 @@ impl<M: Memory> Emulator<u64, M> {
         let (result, _) = self.regs[rs1].overflowing_add(imm as u64);
         self.regs[rd] = result;
         self.pc = self.pc + 4;
+        self.virt.as_mut().map(|v| v.pc += 1);
     }
 
     // #### Memory
@@ -75,6 +196,7 @@ impl<M: Memory> Emulator<u64, M> {
         let (addr, _) = self.regs[rs1].overflowing_add(imm as u64);
         self.regs[rd] = self.mem.read_u64(addr);
         self.pc = self.pc + 4;
+        self.virt.as_mut().map(|v| v.pc += 1);
     }
     // `sd rs2,imm(rs1)`: `memory[rs1 + imm] = rs2; pc = pc + 4` with `-2^11 <= imm < 2^11`
     pub fn sd(&mut self, rs1: usize, rs2: usize, imm: i64) {
@@ -82,6 +204,7 @@ impl<M: Memory> Emulator<u64, M> {
         let (addr, _) = self.regs[rs1].overflowing_add(imm as u64);
         self.mem.write_u64(addr, self.regs[rs2]);
         self.pc = self.pc + 4;
+        self.virt.as_mut().map(|v| v.pc += 1);
     }
 
     // #### Arithmetic
@@ -91,18 +214,21 @@ impl<M: Memory> Emulator<u64, M> {
         let (result, _) = self.regs[rs1].overflowing_add(self.regs[rs2]);
         self.regs[rd] = result;
         self.pc = self.pc + 4;
+        self.virt.as_mut().map(|v| v.pc += 1);
     }
     // `sub rd,rs1,rs2`: `rd = rs1 - rs2; pc = pc + 4`
     pub fn sub(&mut self, rd: usize, rs1: usize, rs2: usize) {
         let (result, _) = self.regs[rs1].overflowing_sub(self.regs[rs2]);
         self.regs[rd] = result;
         self.pc = self.pc + 4;
+        self.virt.as_mut().map(|v| v.pc += 1);
     }
     // `mul rd,rs1,rs2`: `rd = rs1 * rs2; pc = pc + 4`
     pub fn mul(&mut self, rd: usize, rs1: usize, rs2: usize) {
         let (result, _) = self.regs[rs1].overflowing_mul(self.regs[rs2]);
         self.regs[rd] = result;
         self.pc = self.pc + 4;
+        self.virt.as_mut().map(|v| v.pc += 1);
     }
     // `divu rd,rs1,rs2`: `rd = rs1 / rs2; pc = pc + 4` where the values of `rs1` and `rs2` are interpreted as unsigned integers.
     pub fn divu(&mut self, rd: usize, rs1: usize, rs2: usize) {
@@ -115,6 +241,7 @@ impl<M: Memory> Emulator<u64, M> {
         };
         self.regs[rd] = result;
         self.pc = self.pc + 4;
+        self.virt.as_mut().map(|v| v.pc += 1);
     }
     // `remu rd,rs1,rs2`: `rd = rs1 % rs2; pc = pc + 4` where the values of `rs1` and `rs2` are interpreted as unsigned integers.
     pub fn remu(&mut self, rd: usize, rs1: usize, rs2: usize) {
@@ -127,6 +254,7 @@ impl<M: Memory> Emulator<u64, M> {
         };
         self.regs[rd] = result;
         self.pc = self.pc + 4;
+        self.virt.as_mut().map(|v| v.pc += 1);
     }
     // #### Comparison
 
@@ -139,6 +267,7 @@ impl<M: Memory> Emulator<u64, M> {
         };
         self.regs[rd] = result;
         self.pc = self.pc + 4;
+        self.virt.as_mut().map(|v| v.pc += 1);
     }
     // #### Control
 
@@ -149,8 +278,10 @@ impl<M: Memory> Emulator<u64, M> {
             debug_assert_eq!(imm % 2, 0);
             assert_eq!(imm % 4, 0, "instruction-address-misaligned");
             self.pc = (self.pc as i64 + imm as i64) as u64;
+            self.virt.as_mut().map(|v| v.pc = v.vpc_map.get(self.pc));
         } else {
             self.pc = self.pc + 4;
+            self.virt.as_mut().map(|v| v.pc += 1);
         }
     }
     // `jal rd,imm`: `rd = pc + 4; pc = pc + imm` with `-2^20 <= imm < 2^20` and `imm % 2 == 0`
@@ -160,6 +291,7 @@ impl<M: Memory> Emulator<u64, M> {
         assert_eq!(imm % 4, 0, "instruction-address-misaligned");
         self.regs[rd] = self.pc + 4;
         self.pc = (self.pc as i64 + imm as i64) as u64;
+        self.virt.as_mut().map(|v| v.pc = v.vpc_map.get(self.pc));
     }
     // `jalr rd,imm(rs1)`: `tmp = ((rs1 + imm) / 2) * 2; rd = pc + 4; pc = tmp` with `-2^11 <= imm < 2^11`
     pub fn jalr(&mut self, rd: usize, rs1: usize, imm: i64) {
@@ -169,6 +301,7 @@ impl<M: Memory> Emulator<u64, M> {
         assert_eq!(tmp % 4, 0, "instruction-address-misaligned");
         self.regs[rd] = self.pc + 4;
         self.pc = tmp;
+        self.virt.as_mut().map(|v| v.pc = v.vpc_map.get(self.pc));
     }
 
     // #### System
@@ -191,6 +324,60 @@ impl<M: Memory> Emulator<u64, M> {
             }
         }
         self.pc = self.pc + 4;
+        self.virt.as_mut().map(|v| v.pc += 1);
+    }
+
+    // #### Jolt Virtual
+    // NOTE: We use unwrap when updating the vpc to make sure the Virtual extension is enabled.
+    // Running the emulator on Virtual instructions with the Virtual extension not enabled is
+    // unsupported.
+
+    pub fn v_assert_ltu(&mut self, rs1: usize, rs2: usize) {
+        assert!(
+            self.regs[rs1] < self.regs[rs2],
+            "{} >= {}",
+            self.regs[rs1],
+            self.regs[rs2]
+        );
+        self.virt.as_mut().map(|v| v.pc += 1).unwrap();
+    }
+    pub fn v_assert_lte(&mut self, rs1: usize, rs2: usize) {
+        assert!(
+            self.regs[rs1] <= self.regs[rs2],
+            "{} > {}",
+            self.regs[rs1],
+            self.regs[rs2]
+        );
+        self.virt.as_mut().map(|v| v.pc += 1).unwrap();
+    }
+    pub fn v_assert_eq(&mut self, rs1: usize, rs2: usize) {
+        assert!(
+            self.regs[rs1] == self.regs[rs2],
+            "{} != {}",
+            self.regs[rs1],
+            self.regs[rs2]
+        );
+        self.virt.as_mut().map(|v| v.pc += 1).unwrap();
+    }
+    pub fn v_advice(&mut self, rd: usize) {
+        let mut advice = 0;
+        self.virt.as_mut().map(|v| {
+            // This vector is filled in the fetch step when virt is enabled.
+            advice = v.advices.pop().unwrap();
+            v.last_advice = Some(advice);
+        });
+        self.regs[rd] = advice;
+        self.virt.as_mut().map(|v| v.pc += 1).unwrap();
+    }
+    pub fn v_add(&mut self, rd: usize, rs1: usize, rs2: usize) {
+        let (result, _) = self.regs[rs1].overflowing_add(self.regs[rs2]);
+        self.regs[rd] = result;
+        self.virt.as_mut().map(|v| v.pc += 1);
+    }
+    pub fn v_mul(&mut self, rd: usize, rs1: usize, rs2: usize) {
+        let (result, _) = self.regs[rs1].overflowing_mul(self.regs[rs2]);
+        self.regs[rd] = result;
+        self.virt.as_mut().map(|v| v.pc += 1);
     }
 }
 
@@ -220,21 +407,51 @@ impl<M: Memory> Emulator<u64, M> {
             Jal => self.jal(rd, imm),
             Jalr => self.jalr(rd, rs1, imm),
             Ecall => self.ecall(),
+            Virtual(vop) => match vop {
+                VirtualOpcode::AssertLtu => self.v_assert_ltu(rs1, rs2),
+                VirtualOpcode::AssertLte => self.v_assert_lte(rs1, rs2),
+                VirtualOpcode::AssertEq => self.v_assert_eq(rs1, rs2),
+                VirtualOpcode::Advice => self.v_advice(rd),
+                VirtualOpcode::Add => self.v_add(rd, rs1, rs2),
+                VirtualOpcode::Mul => self.v_mul(rd, rs1, rs2),
+            },
         }
     }
     pub fn step(&mut self) -> Instruction {
+        use Opcode::*;
         // Fetch
         let inst_u32 = self.mem.fetch_u32(self.pc);
         // Decode
         let inst = decode(inst_u32).expect("Valid instruction");
-        self.exec(inst.clone());
-        inst
+        let real_inst = if let Some(ref mut virt) = self.virt {
+            // If we have a multi-step instruction that requires advice, fill the advice buffer
+            // here.
+            if virt.begin_multi_step.contains(&virt.pc) {
+                match inst.op {
+                    Divu | Remu => {
+                        let (quotient, _) =
+                            self.regs[inst.rs1].overflowing_div(self.regs[inst.rs2]);
+                        let (remainder, _) =
+                            self.regs[inst.rs1].overflowing_rem(self.regs[inst.rs2]);
+                        virt.advices = vec![remainder, quotient];
+                    }
+                    _ => {}
+                }
+            }
+            // Get already decoded instruction (possibly virtual)
+            virt.rom[virt.pc as usize].clone()
+        } else {
+            inst
+        };
+        self.exec(real_inst.clone());
+        real_inst
     }
 }
 
 impl<M: Memory> Emulator<u64, MemoryTracer<M>> {
     pub fn exec_trace(&mut self, inst: Instruction) -> Step<u64> {
         let pc = self.pc;
+        let vpc = self.virt.as_ref().map(|v| v.pc).unwrap_or(0);
         let regs = self.regs.clone();
         let mem_t = self.mem.t;
         self.exec(inst.clone());
@@ -242,16 +459,24 @@ impl<M: Memory> Emulator<u64, MemoryTracer<M>> {
         // instruction execution.
         let mem_ops = self.mem.trace.clone();
         self.mem.trace.clear();
+        let advice = self
+            .virt
+            .as_ref()
+            .map(|v| v.last_advice.unwrap_or(0))
+            .unwrap_or(0);
         Step {
             inst,
             pc,
+            vpc,
             regs,
             mem_t,
             mem_ops,
+            advice,
         }
     }
     pub fn step_trace(&mut self) -> Step<u64> {
         let pc = self.pc;
+        let vpc = self.virt.as_ref().map(|v| v.pc).unwrap_or(0);
         let regs = self.regs.clone();
         let mem_t = self.mem.t;
         let inst = self.step();
@@ -259,12 +484,19 @@ impl<M: Memory> Emulator<u64, MemoryTracer<M>> {
         // from load / store instruction
         let mem_ops = self.mem.trace[4..].into();
         self.mem.trace.clear();
+        let advice = self
+            .virt
+            .as_ref()
+            .map(|v| v.last_advice.unwrap_or(0))
+            .unwrap_or(0);
         Step {
             inst,
             pc,
+            vpc,
             regs,
             mem_t,
             mem_ops,
+            advice,
         }
     }
 }

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -456,6 +456,7 @@ impl From<Instruction> for JoltInstruction {
                 opflags.is_positive = if inst.imm >= 0 { true } else { false };
             }
             Opcode::Ecall => {}
+            Opcode::Virtual(vop) => todo!(),
         };
         let imm = if opflags.branch & !opflags.is_positive {
             inst.imm.unsigned_abs()
@@ -477,10 +478,12 @@ impl<F: From<u64>> From<GenericStep<u64, Instruction>> for GenericStep<F, JoltIn
     fn from(step: GenericStep<u64, Instruction>) -> Self {
         Step {
             pc: F::from(step.pc),
+            vpc: F::from(step.vpc),
             inst: step.inst.into(),
             regs: step.regs.into_f(),
             mem_ops: step.mem_ops,
             mem_t: step.mem_t,
+            advice: step.advice.into(),
         }
     }
 }


### PR DESCRIPTION
- Extend the register set to accommodate virtual registers
- Extend the Opcode list to accommodate the following virtual instructions: AssertLtu, AssertLte, AssertEq, Advice, Add, Mul
- Add a flag to the emulator to enable the virtual extension, this will do the following:
  - Preprocess the program and replace any multi-step instruction by the corresponding virtual instructions, while keeping a map between original pc and new virtual pc
  - When stepping, if a multi-step instruction is found, prepare the advice that will be needed for the ADVICE virtual instructions that will come
  - When stepping, instead of using the original instruction fetched from memory, use the already decoded instruction list which includes the virtual ones.
  - In every step, advance the virtual pc too.

Changes from Jolt paper:
- In section 6.1.1 only AssertLt and AssertEq are defined, but then in section 6.3 AssertLte and AssertLtu are used, so this means in total we need 3 Assert instructions
- DIVU and REMU use Add and Mul.  These instructions are not virtual, and as such will increase the pc; but that would break the correct behaviour because the pc shouldn't change while the instructions that emulate DIVU and REMU are being executed.  For this reason I introduced a virtual Add and virtual Mul which behave like the original ones but without increasing the pc.
- Section 6.1.2 defines the MOVE instruction.  This feels very weird to me because RISC-V has a special register (r0) which is the zero register, every time we read from it we get a 0.  With this register it's trivial to implement a MOVE by doing `ADD rd = rs1 + zero` (in fact this is the canonical way to implement the `mv` pseudoinstruction following the RISC-V spec).  The fact that this was not considered by Jolt makes me wonder if they are aware of the zero register and it's special behavior (special constraints will be needed for the zero register).
---
Resolve https://github.com/ed255/riscu-jolt/issues/25
The missing part is to implement the virtual instructions in the simulator